### PR TITLE
Fix README custom domain confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Simply open [Lovable](https://lovable.dev/projects/92fe03a6-1bd0-4890-bef4-8f03f
 
 ## Can I connect a custom domain to my Lovable project?
 
-Yes it is!
+Yes, you can!
 
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 


### PR DESCRIPTION
## Summary
- clarify the confirmation text about connecting a custom domain in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

## Summary by Sourcery

Documentation:
- Update the custom domain confirmation text in README from 'Yes it is!' to 'Yes, you can!'