### PR TITLE
Fix toast listener effect dependencies

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure toast listener is only registered once

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*