### PR TITLE
Persist ElevenLabs API key

### DIFF
--- a/src/hooks/use-transcription.tsx
+++ b/src/hooks/use-transcription.tsx
@@ -17,14 +17,16 @@ export const useTranscription = () => {
   const { showNotification } = useNotification();
   const [isRecording, setIsRecording] = useState(false);
   const [transcriptLines, setTranscriptLines] = useState<TranscriptionLine[]>([]);
-  const [apiKeyInput, setApiKeyInput] = useState(getApiKey());
+  const [apiKeyInput, setApiKeyInput] = useState('');
   const [showApiKeyDialog, setShowApiKeyDialog] = useState(false);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
 
-  // Controleer of er al een API sleutel is ingesteld
+  // Laad de API sleutel uit localStorage bij het laden van de hook
   useEffect(() => {
-    if (!getApiKey()) {
+    const key = getApiKey();
+    setApiKeyInput(key);
+    if (!key) {
       setShowApiKeyDialog(true);
     }
   }, []);

--- a/src/services/elevenLabsService.ts
+++ b/src/services/elevenLabsService.ts
@@ -14,13 +14,37 @@ export interface VoiceSettings {
 }
 
 // Deze API sleutel zou in de toekomst uit Supabase secrets moeten komen
+const STORAGE_KEY = 'elevenLabsApiKey';
 let apiKey = '';
+
+// Initialiseert de apiKey vanuit localStorage indien beschikbaar
+if (typeof window !== 'undefined') {
+  const storedKey = localStorage.getItem(STORAGE_KEY);
+  if (storedKey) {
+    apiKey = storedKey;
+  }
+}
 
 export const setApiKey = (key: string) => {
   apiKey = key;
+  try {
+    if (key) {
+      localStorage.setItem(STORAGE_KEY, key);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  } catch (e) {
+    console.error('Kon API sleutel niet opslaan in localStorage', e);
+  }
 };
 
-export const getApiKey = () => apiKey;
+export const getApiKey = () => {
+  if (!apiKey && typeof window !== 'undefined') {
+    const storedKey = localStorage.getItem(STORAGE_KEY);
+    if (storedKey) apiKey = storedKey;
+  }
+  return apiKey;
+};
 
 export const DEFAULT_VOICE_ID = "9BWtsMINqrJLrRacOk9x"; // Aria stem
 


### PR DESCRIPTION
## Summary
- keep the ElevenLabs API key in `localStorage`
- load the stored key on mount in the transcription hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*