### PR TITLE
Add basic test setup and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for the project
+# Copy this file to .env and fill in your keys
+
+# API key used by the ElevenLabs service
+ELEVENLABS_API_KEY=your-api-key-here
+
+# Port for the local backend server
+PORT=3001

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ Voor de telefoonfunctionaliteit is een API sleutel van [ElevenLabs](https://elev
 
 Zonder geldige sleutel werkt de live transcriptie en spraaksynthese niet.
 
+### .env bestand
+
+Voor lokaal gebruik kun je een `.env` bestand aanmaken op basis van `.env.example`.
+Hierin zet je je `ELEVENLABS_API_KEY` en eventueel een andere `PORT` voor de
+backend server. Start de server vervolgens met:
+
+```sh
+npm run backend
+```
+
+### Tests draaien
+
+Er staat een klein voorbeeldtestje in de map `tests`. Voer alle tests uit met:
+
+```sh
+npm test
+```
+
 ## How can I edit this code?
 
 There are several ways of editing your application.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "backend": "node server/server.cjs"
+    "backend": "node --env-file=.env server/server.cjs",
+    "test": "node --test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/services/elevenLabsService.ts
+++ b/src/services/elevenLabsService.ts
@@ -17,6 +17,14 @@ export interface VoiceSettings {
 const STORAGE_KEY = 'elevenLabsApiKey';
 let apiKey = '';
 
+// Haal een eventueel ingestelde API key uit Vite env variabelen
+if (!apiKey && typeof import.meta !== 'undefined') {
+  const envKey = import.meta.env.VITE_ELEVENLABS_API_KEY;
+  if (envKey) {
+    apiKey = envKey as string;
+  }
+}
+
 // Initialiseert de apiKey vanuit localStorage indien beschikbaar
 if (typeof window !== 'undefined') {
   const storedKey = localStorage.getItem(STORAGE_KEY);

--- a/tests/example.test.js
+++ b/tests/example.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+test('basic arithmetic', () => {
+  assert.strictEqual(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- provide `.env.example` for API keys and backend port
- ignore local `.env` files
- load `VITE_ELEVENLABS_API_KEY` in ElevenLabs service
- document env usage and test command in README
- add node builtin test with `npm test`

## Testing
- `npm test`